### PR TITLE
Localize ask form control copy

### DIFF
--- a/extensions/ask-user-question/i18n.ts
+++ b/extensions/ask-user-question/i18n.ts
@@ -1,0 +1,93 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+	es: {
+		"ask.pressEnterSubmit": "Pulsa Enter para enviar",
+		"ask.required": "Obligatorio: {missing}",
+		"ask.navQuestions": "Tab/←→ navegar preguntas • Enter enviar • Esc cancelar",
+		"ask.type.single": "[selección única]",
+		"ask.type.multi": "[selección múltiple]",
+		"ask.type.text": "[texto]",
+		"ask.requiredMark": "*obligatorio",
+		"ask.other": "Otro...",
+		"ask.otherValue": "Otro: {value}",
+		"ask.yourAnswer": "Tu respuesta:",
+		"ask.enterBack": "Enter enviar • Esc volver",
+		"ask.textFooter": "{nav}Enter enviar • Esc cancelar",
+		"ask.checkboxFooter": "↑↓ navegar • Space alternar • {nav}Enter {action} • Esc cancelar",
+		"ask.radioFooter": "↑↓ navegar • {nav}Enter seleccionar • Esc cancelar",
+		"ask.next": "siguiente",
+		"ask.submit": "enviar",
+		"ask.cancelled": "El usuario canceló el formulario",
+	},
+	fr: {
+		"ask.pressEnterSubmit": "Appuyez sur Entrée pour envoyer",
+		"ask.required": "Obligatoire : {missing}",
+		"ask.navQuestions": "Tab/←→ parcourir les questions • Entrée envoyer • Échap annuler",
+		"ask.type.single": "[sélection unique]",
+		"ask.type.multi": "[sélection multiple]",
+		"ask.type.text": "[texte]",
+		"ask.requiredMark": "*obligatoire",
+		"ask.other": "Autre...",
+		"ask.otherValue": "Autre : {value}",
+		"ask.yourAnswer": "Votre réponse :",
+		"ask.enterBack": "Entrée envoyer • Échap revenir",
+		"ask.textFooter": "{nav}Entrée envoyer • Échap annuler",
+		"ask.checkboxFooter": "↑↓ naviguer • Espace basculer • {nav}Entrée {action} • Échap annuler",
+		"ask.radioFooter": "↑↓ naviguer • {nav}Entrée sélectionner • Échap annuler",
+		"ask.next": "suivant",
+		"ask.submit": "envoyer",
+		"ask.cancelled": "L’utilisateur a annulé le formulaire",
+	},
+	"pt-BR": {
+		"ask.pressEnterSubmit": "Pressione Enter para enviar",
+		"ask.required": "Obrigatório: {missing}",
+		"ask.navQuestions": "Tab/←→ navegar perguntas • Enter enviar • Esc cancelar",
+		"ask.type.single": "[seleção única]",
+		"ask.type.multi": "[seleção múltipla]",
+		"ask.type.text": "[texto]",
+		"ask.requiredMark": "*obrigatório",
+		"ask.other": "Outro...",
+		"ask.otherValue": "Outro: {value}",
+		"ask.yourAnswer": "Sua resposta:",
+		"ask.enterBack": "Enter enviar • Esc voltar",
+		"ask.textFooter": "{nav}Enter enviar • Esc cancelar",
+		"ask.checkboxFooter": "↑↓ navegar • Space alternar • {nav}Enter {action} • Esc cancelar",
+		"ask.radioFooter": "↑↓ navegar • {nav}Enter selecionar • Esc cancelar",
+		"ask.next": "próxima",
+		"ask.submit": "enviar",
+		"ask.cancelled": "O usuário cancelou o formulário",
+	},
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: ExtensionAPI): void {
+	pi.events?.emit?.("pi-core/i18n/registerBundle", {
+		namespace: "pi-mono-ask-user-question",
+		defaultLocale: "en",
+		locales: translations,
+	});
+
+	pi.events?.emit?.("pi-core/i18n/requestApi", {
+		onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+			const next = api.getLocale?.();
+			if (isLocale(next)) currentLocale = next;
+			api.onLocaleChange?.((locale) => {
+				if (isLocale(locale)) currentLocale = locale;
+			});
+		},
+	});
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+	const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+	return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+	return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}

--- a/extensions/ask-user-question/index.ts
+++ b/extensions/ask-user-question/index.ts
@@ -21,6 +21,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Editor, type EditorTheme, Key, matchesKey, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
+import { initI18n, t } from "./i18n.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -158,6 +159,8 @@ const SYM = {
 // ─── Extension ───────────────────────────────────────────────────────────────
 
 export default function askUserQuestion(pi: ExtensionAPI) {
+	initI18n(pi);
+
 	pi.registerTool({
 		name: "ask_user_question",
 		label: "Ask User",
@@ -664,17 +667,17 @@ Use this tool when you need user input to proceed — for clarifying requirement
 
 						lines.push("");
 						if (allRequired()) {
-							add(` ${theme.fg("success", "Press Enter to submit")}`);
+							add(` ${theme.fg("success", t("ask.pressEnterSubmit", "Press Enter to submit"))}`);
 						} else {
 							const missing = questions
 								.filter((q) => q.required && !isAnswered(q))
 								.map((q) => q.label)
 								.join(", ");
-							add(` ${theme.fg("warning", `Required: ${missing}`)}`);
+							add(` ${theme.fg("warning", t("ask.required", "Required: {missing}", { missing }))}`);
 						}
 
 						lines.push("");
-						add(theme.fg("dim", " Tab/←→ navigate questions • Enter submit • Esc cancel"));
+						add(theme.fg("dim", ` ${t("ask.navQuestions", "Tab/←→ navigate questions • Enter submit • Esc cancel")}`));
 						hr();
 						cachedLines = lines;
 						return lines;
@@ -689,10 +692,10 @@ Use this tool when you need user input to proceed — for clarifying requirement
 					// ── Question prompt ──────────────────────────────────
 					const typeTag =
 						q.type === "radio"
-							? theme.fg("dim", "[single-select]")
+							? theme.fg("dim", t("ask.type.single", "[single-select]"))
 							: q.type === "checkbox"
-								? theme.fg("dim", "[multi-select]")
-								: theme.fg("dim", "[text]");
+								? theme.fg("dim", t("ask.type.multi", "[multi-select]"))
+								: theme.fg("dim", t("ask.type.text", "[text]"));
 
 					const promptLines = wrapText(q.prompt, maxW - 2);
 					for (let i = 0; i < promptLines.length; i++) {
@@ -700,7 +703,7 @@ Use this tool when you need user input to proceed — for clarifying requirement
 						add(` ${theme.fg("text", theme.bold(promptLines[i]))}${isLast ? ` ${typeTag}` : ""}`);
 					}
 					if (q.required) {
-						add(` ${theme.fg("warning", "*required")}`);
+						add(` ${theme.fg("warning", t("ask.requiredMark", "*required"))}`);
 					}
 					lines.push("");
 
@@ -733,7 +736,9 @@ Use this tool when you need user input to proceed — for clarifying requirement
 							const isSelected = selected?.wasCustom === true;
 							const bullet = isSelected ? theme.fg("accent", SYM.radioOn) : theme.fg("dim", SYM.radioOff);
 							const pointer = isCursor ? theme.fg("accent", SYM.pointer) : " ";
-							const label = isSelected ? `Other: ${selected.label}` : "Other...";
+							const label = isSelected
+								? t("ask.otherValue", "Other: {value}", { value: selected.label })
+								: t("ask.other", "Other...");
 							const prefix = ` ${pointer} ${bullet} `;
 							const prefixWidth = visibleWidth(prefix);
 							const labelLines = wrapText(label, Math.max(1, maxW - prefixWidth));
@@ -745,7 +750,7 @@ Use this tool when you need user input to proceed — for clarifying requirement
 
 							if (otherMode) {
 								lines.push("");
-								add(` ${theme.fg("muted", "  Your answer:")}`);
+								add(`   ${theme.fg("muted", t("ask.yourAnswer", "Your answer:"))}`);
 								for (const line of editor.render(maxW - 6)) {
 									add(`   ${line}`);
 								}
@@ -782,7 +787,7 @@ Use this tool when you need user input to proceed — for clarifying requirement
 							const custom = checkCustom.get(q.id)?.trim();
 							const box = custom ? theme.fg("accent", SYM.checkOn) : theme.fg("dim", SYM.checkOff);
 							const pointer = isCursor ? theme.fg("accent", SYM.pointer) : " ";
-							const label = custom ? `Other: ${custom}` : "Other...";
+							const label = custom ? t("ask.otherValue", "Other: {value}", { value: custom }) : t("ask.other", "Other...");
 							const prefix = ` ${pointer} ${box} `;
 							const prefixWidth = visibleWidth(prefix);
 							const labelLines = wrapText(label, Math.max(1, maxW - prefixWidth));
@@ -807,16 +812,16 @@ Use this tool when you need user input to proceed — for clarifying requirement
 					// ── Footer ───────────────────────────────────────────
 					lines.push("");
 					if (otherMode) {
-						add(theme.fg("dim", " Enter submit • Esc go back"));
+						add(theme.fg("dim", ` ${t("ask.enterBack", "Enter submit • Esc go back")}`));
 					} else if (q.type === "text") {
 						const nav = isMulti ? "Tab/←→ navigate • " : "";
-						add(theme.fg("dim", ` ${nav}Enter submit • Esc cancel`));
+						add(theme.fg("dim", ` ${t("ask.textFooter", "{nav}Enter submit • Esc cancel", { nav })}`));
 					} else if (q.type === "checkbox") {
 						const nav = isMulti ? "Tab/←→ navigate • " : "";
-						add(theme.fg("dim", ` ↑↓ navigate • Space toggle • ${nav}Enter ${isMulti ? "next" : "submit"} • Esc cancel`));
+						add(theme.fg("dim", ` ${t("ask.checkboxFooter", "↑↓ navigate • Space toggle • {nav}Enter {action} • Esc cancel", { nav, action: isMulti ? t("ask.next", "next") : t("ask.submit", "submit") })}`));
 					} else {
 						const nav = isMulti ? "Tab/←→ navigate • " : "";
-						add(theme.fg("dim", ` ↑↓ navigate • ${nav}Enter select • Esc cancel`));
+						add(theme.fg("dim", ` ${t("ask.radioFooter", "↑↓ navigate • {nav}Enter select • Esc cancel", { nav })}`));
 					}
 					hr();
 
@@ -843,7 +848,7 @@ Use this tool when you need user input to proceed — for clarifying requirement
 
 			if (result.cancelled) {
 				return {
-					content: [{ type: "text", text: "User cancelled the form" }],
+					content: [{ type: "text", text: t("ask.cancelled", "User cancelled the form") }],
 					details: result,
 				};
 			}


### PR DESCRIPTION
`ask_user_question` is a human decision point: the user is choosing options, moving between questions, submitting, or cancelling. I kept this focused on the form-control copy that affects that handoff, rather than translating tool schemas, examples, or maintainer-authored docs.

What changed:
- added a tiny optional i18n bridge for `pi-mono-ask-user-question`
- registered `es`, `fr`, and `pt-BR` strings
- wrapped only form-control/status copy: submit/cancel/navigation, required/missing labels, type tags, Other labels, and cancellation result

What did not change:
- no required dependency
- no behavior change without a Pi i18n provider
- English fallback strings stay in the call sites
- no README, package metadata, examples, or tool schema text changed
- easy to revert by deleting `i18n.ts` and the small wrappers in `index.ts`

Validation:
- `npx esbuild extensions/ask-user-question/index.ts --bundle --platform=node --format=esm --outfile=... --external:@mariozechner/pi-coding-agent --external:@mariozechner/pi-tui --external:@sinclair/typebox` passed
- `npm pack --dry-run` from `extensions/ask-user-question` passed
- targeted strict `tsc` is blocked by existing public API typing where `params`/`args` are `unknown`, unrelated to these string wrappers

If useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.
