### PR TITLE
fix: clear read dedup cache before compaction

### DIFF
--- a/extensions/context-guard/index.ts
+++ b/extensions/context-guard/index.ts
@@ -94,6 +94,22 @@ export default function (pi: ExtensionAPI): void {
 	});
 
 	// -------------------------------------------------------------------------
+	// Clear cache before compaction — file contents are lost but cache
+	// entries would still block re-reads with "File unchanged since last read".
+	// -------------------------------------------------------------------------
+	pi.on("session_before_compact", async () => {
+		readCache.clear();
+	});
+
+	// -------------------------------------------------------------------------
+	// Cache clear — allows external extensions to invalidate the dedup cache.
+	// Emitted via pi.events.emit("context-guard:clear-cache").
+	// -------------------------------------------------------------------------
+	pi.events.on("context-guard:clear-cache", () => {
+		readCache.clear();
+	});
+
+	// -------------------------------------------------------------------------
 	// Reset cache on new session
 	// -------------------------------------------------------------------------
 	pi.on("session_start", async () => {


### PR DESCRIPTION
## Problem

The read dedup cache (`readCache` Map) is module-scoped and only cleared on `session_start`. When a compaction occurs within the same session (e.g. handoff), the cache still has entries but the actual file contents were lost from the LLM context during compaction.

This causes the guard to return the `"File unchanged since last read"` stub on subsequent reads of those files — the LLM cannot recover the content.

Closes #4

## Fix

Two changes:

1. **`pi.on("session_before_compact")` listener** — clears `readCache` automatically before every compaction. This is the primary fix and requires no coordination from other extensions.

2. **`"context-guard:clear-cache"` event listener** — allows external extensions to invalidate the dedup cache on demand via `pi.events.emit("context-guard:clear-cache")`. Useful for custom compaction flows or other scenarios where the cache should be cleared.

## Testing

- Verified `session_before_compact` hook exists in pi's extension API and fires before compaction
- Verified `readCache.clear()` is idempotent and safe to call multiple times
- Existing session_start clearing remains unchanged